### PR TITLE
fix * selector bug

### DIFF
--- a/lib/filter.js
+++ b/lib/filter.js
@@ -21,9 +21,9 @@ function filter (css, selectors) {
       return arr
     } else if (rule.type === 'rule') {
       rule.selectors.forEach(function (select) {
+        if (select === '*') return arr.push(rule)
         var selector = select.match(/([.#]?[\w\d-_]+)/)
         if (selector) selector = selector[1]
-        if (selector === '*') arr.push(rule)
         if (selectors.indexOf(selector) !== -1) {
           arr.push(rule)
         }

--- a/test.js
+++ b/test.js
@@ -266,3 +266,35 @@ tape('ignores extra ids', function (assert) {
 
   source.end(html)
 })
+
+tape('can parse * selector', function (assert) {
+  assert.plan(2)
+  var css = `
+    * { box-sizing: border-box; }
+  `
+
+  var html = `
+    <html>
+      <head></head>
+      <body>Hello world</body>
+    </html>
+  `
+
+  var expected = `
+    <html>
+      <head><style>*{box-sizing:border-box;}</style></head>
+      <body>Hello world</body>
+    </html>
+  `
+
+  var source = inline(css)
+  var sink = concat({ encoding: 'string' }, function (str) {
+    assert.equal(str, expected, 'was inlined')
+  })
+
+  pump(source, sink, function (err) {
+    assert.ifError(err, 'no error pumping')
+  })
+
+  source.end(html)
+})


### PR DESCRIPTION
Previously, `filter.js` never returned `*` selectors. Fixed the bug and added a test.

Now the following is correctly inlined:

```css
* { box-sizing: border-box; }
```