### PR TITLE
Speed up by switching to hstream

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var extractId = require('extract-html-id')
 var extractTag = require('extract-html-tag')
 var eos = require('end-of-stream')
 var through = require('through2')
-var hs = require('hyperstream')
+var hs = require('hstream')
 var assert = require('assert')
 
 var filter = require('./lib/filter')

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "extract-html-class": "^1.0.1",
     "extract-html-id": "^1.0.0",
     "extract-html-tag": "^1.0.1",
-    "hyperstream": "^1.2.2",
+    "hstream": "^1.0.0",
     "through2": "^2.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
[hstream](https://github.com/goto-bus-stop/hstream) is a fast
hyperstream alternative. It lacks some features, but inline-critical-css
only needs to append some tags to the `<head>`, and that _does_ work.

Unscientific test suggests ~2× speedup:

```
$ git checkout master
$ time node test
...
node test  0.27s user 0.02s system 105% cpu 0.269 total
```

```
$ git checkout hstream
$ time node test
...
node test  0.14s user 0.01s system 104% cpu 0.147 total
```

This should help bankai SSR be a bit speedier, combined with the work in
https://github.com/choojs/bankai/pull/394