### PR TITLE
Only match combined selectors once

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ function inline (css) {
     }).concat(extractId(src).map(function (id) {
       return '#' + id
     })).concat(extractTag(src))
+
     var critical = filter(css, valid)
     var style = ''
     if (critical) {

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -20,14 +20,15 @@ function filter (css, selectors) {
       if (rule.rules.length) arr.push(rule) // Don't push empty media queries
       return arr
     } else if (rule.type === 'rule') {
-      rule.selectors.forEach(function (select) {
-        if (select === '*') return arr.push(rule)
+      var matches = rule.selectors.some(function (select) {
+        if (select === '*') return true
         var selector = select.match(/([.#]?[\w\d-_]+)/)
         if (selector) selector = selector[1]
-        if (selectors.indexOf(selector) !== -1) {
-          arr.push(rule)
-        }
+        return selectors.indexOf(selector) !== -1
       })
+      if (matches) {
+        arr.push(rule)
+      }
     }
     return arr
   }

--- a/test.js
+++ b/test.js
@@ -298,3 +298,42 @@ tape('can parse * selector', function (assert) {
 
   source.end(html)
 })
+
+tape('can parse multiple selectors', function (assert) {
+  assert.plan(2)
+  var css = `
+    a, div, p, body, main { box-sizing: border-box; }
+  `
+  var html = `
+    <html>
+      <head></head>
+      <body>
+        <main>
+          <p>Hello world</p>
+        </main>
+      </body>
+    </html>
+  `
+
+  var expected = `
+    <html>
+      <head><style>a,div,p,body,main{box-sizing:border-box;}</style></head>
+      <body>
+        <main>
+          <p>Hello world</p>
+        </main>
+      </body>
+    </html>
+  `
+
+  var source = inline(css)
+  var sink = concat({ encoding: 'string' }, function (str) {
+    assert.equal(str, expected, 'was inlined')
+  })
+
+  pump(source, sink, function (err) {
+    assert.ifError(err, 'no error pumping')
+  })
+
+  source.end(html)
+})


### PR DESCRIPTION
Previously, a rule like `div, p {}` would be added to the output twice
if both selectors matched. With this patch, a rule is only added once
if any of its selectors match.